### PR TITLE
feat: allow click‐through on fog overlays

### DIFF
--- a/.changeset/kind-spiders-report.md
+++ b/.changeset/kind-spiders-report.md
@@ -1,0 +1,5 @@
+---
+"react-fog": patch
+---
+
+allow click‑through on fog overlays

--- a/src/FogEffect.tsx
+++ b/src/FogEffect.tsx
@@ -40,6 +40,7 @@ export default function FogEffect({
         position: "absolute",
         zIndex: 999,
         background: getBackground(),
+        pointerEvents: 'none'
       }}
       {...props}
     />


### PR DESCRIPTION
When a fog overlay is active, it intercepts all pointer events—even on inputs below—so you can’t click or focus them.

## 📹 GIF showing the issue


![ezgif-10200b7c6aec98](https://github.com/user-attachments/assets/1d57a240-5e53-493d-9417-cfef2baf71dc)

## 🔧 Steps to reproduce

1. Render a scrollable container
2. Place an `<input>` or `<button>` inside the fog region  
3. Attempt to click/focus the input  
4. Observe that clicks never reach the underlying element

## ✅ Expected behavior

Clicks and focus events should “pass through” the fog, allowing interaction with underlying inputs.

## 💡 Proposed solution

Add `pointer-events: none` to the fog overlay styles so mouse events go through: